### PR TITLE
forkinstaller has a different checksum

### DIFF
--- a/automatic/git-fork/tools/chocolateyInstall.ps1
+++ b/automatic/git-fork/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@
 $packageArgs = @{
   packageName    = 'git-fork'
   url            = 'https://git-fork.com/update/win/ForkInstaller.exe'
-  checksum       = '1287b648a5797fc15eebd25b67007c86368751f9821458f676409511d5a34167'
+  checksum       = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
   checksumType   = 'sha256'
   installerType  = 'exe'
   silentArgs    = '/s'


### PR DESCRIPTION
choco install git-fork fails with a checksum error now. So this suggested change is the result of running the following

```shell
wget https://git-fork.com/update/win/ForkInstaller.exe | sha256sum
```