### PR TITLE
fix: silent flag for fork.dev choco installer

### DIFF
--- a/automatic/git-fork/tools/chocolateyInstall.ps1
+++ b/automatic/git-fork/tools/chocolateyInstall.ps1
@@ -7,7 +7,7 @@ $packageArgs = @{
   checksum       = '1287b648a5797fc15eebd25b67007c86368751f9821458f676409511d5a34167'
   checksumType   = 'sha256'
   installerType  = 'exe'
-  silentArgs    = '/s'
+  silentArgs    = '--silent'
   validExitCodes = @(0)
 }
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Change silent installer switch from `/s` to `--silent` now that they seem to use Velopack for the installer

fixes #14